### PR TITLE
Fix: Fixed the error message obfuscation issue.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.4
+
+- fix: Improved error handling and reporting by ensuring last_error_ is reset per method call and adding descriptive logs for window visibility failures.
+
 ## 1.1.3
 
 - fix: resolve taskbar icon handle leak

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: windows_taskbar
 description: Flutter plugin serving utilities related to Windows taskbar.
-version: 1.1.3
+version: 1.1.4
 homepage: https://github.com/alexmercerind/windows_taskbar
 repository: https://github.com/alexmercerind/windows_taskbar
 

--- a/windows/windows_taskbar.cc
+++ b/windows/windows_taskbar.cc
@@ -50,8 +50,12 @@ WindowsTaskbar::~WindowsTaskbar() {
   }
 }
 
-bool WindowsTaskbar::SetProgressMode(int32_t mode) {
+void WindowsTaskbar::ResetLastError() {
   last_error_ = "";
+}
+
+bool WindowsTaskbar::SetProgressMode(int32_t mode) {
+  ResetLastError();
   if (!::IsWindowVisible(window_)) {
     LOG_ERROR("SetProgressMode failed: Window is not visible.");
     return false;
@@ -70,7 +74,7 @@ bool WindowsTaskbar::SetProgressMode(int32_t mode) {
 }
 
 bool WindowsTaskbar::SetProgress(int32_t completed, int32_t total) {
-  last_error_ = "";
+  ResetLastError();
   if (!::IsWindowVisible(window_)) {
     LOG_ERROR("SetProgress failed: Window is not visible.");
     return false;
@@ -89,7 +93,7 @@ bool WindowsTaskbar::SetProgress(int32_t completed, int32_t total) {
 
 bool WindowsTaskbar::SetThumbnailToolbar(
     std::vector<ThumbnailToolbarButton> buttons) {
-  last_error_ = "";
+  ResetLastError();
   if (!::IsWindowVisible(window_)) {
     LOG_ERROR("SetThumbnailToolbar failed: Window is not visible.");
     return false;
@@ -191,12 +195,12 @@ bool WindowsTaskbar::SetThumbnailToolbar(
 }
 
 bool WindowsTaskbar::ResetThumbnailToolbar() {
-  last_error_ = "";
+  ResetLastError();
   return WindowsTaskbar::SetThumbnailToolbar({});
 }
 
 bool WindowsTaskbar::SetThumbnailTooltip(std::string tooltip) {
-  last_error_ = "";
+  ResetLastError();
   if (!::IsWindowVisible(window_)) {
     LOG_ERROR("SetThumbnailTooltip failed: Window is not visible.");
     return false;
@@ -212,7 +216,7 @@ bool WindowsTaskbar::SetThumbnailTooltip(std::string tooltip) {
 
 bool WindowsTaskbar::SetFlashTaskbarAppIcon(int32_t mode, int32_t flash_count,
                                             int32_t timeout) {
-  last_error_ = "";
+  ResetLastError();
   if (!::IsWindowVisible(window_)) {
     LOG_ERROR("SetFlashTaskbarAppIcon failed: Window is not visible.");
     return false;
@@ -229,7 +233,7 @@ bool WindowsTaskbar::SetFlashTaskbarAppIcon(int32_t mode, int32_t flash_count,
 }
 
 bool WindowsTaskbar::ResetFlashTaskbarAppIcon() {
-  last_error_ = "";
+  ResetLastError();
   if (!::IsWindowVisible(window_)) {
     LOG_ERROR("ResetFlashTaskbarAppIcon failed: Window is not visible.");
     return false;
@@ -246,7 +250,7 @@ bool WindowsTaskbar::ResetFlashTaskbarAppIcon() {
 }
 
 bool WindowsTaskbar::SetOverlayIcon(std::string icon, std::string tooltip) {
-  last_error_ = "";
+  ResetLastError();
   if (!::IsWindowVisible(window_)) {
     LOG_ERROR("SetOverlayIcon failed: Window is not visible.");
     return false;
@@ -269,7 +273,7 @@ bool WindowsTaskbar::SetOverlayIcon(std::string icon, std::string tooltip) {
 }
 
 bool WindowsTaskbar::ResetOverlayIcon() {
-  last_error_ = "";
+  ResetLastError();
   if (!::IsWindowVisible(window_)) {
     LOG_ERROR("ResetOverlayIcon failed: Window is not visible.");
     return false;
@@ -283,7 +287,7 @@ bool WindowsTaskbar::ResetOverlayIcon() {
 }
 
 bool WindowsTaskbar::SetWindowTitle(std::string title) {
-  last_error_ = "";
+  ResetLastError();
   if (!::IsWindowVisible(window_)) {
     LOG_ERROR("SetWindowTitle failed: Window is not visible.");
     return false;
@@ -300,7 +304,7 @@ bool WindowsTaskbar::SetWindowTitle(std::string title) {
 }
 
 bool WindowsTaskbar::ResetWindowTitle() {
-  last_error_ = "";
+  ResetLastError();
   if (!::IsWindowVisible(window_)) {
     LOG_ERROR("ResetWindowTitle failed: Window is not visible.");
     return false;

--- a/windows/windows_taskbar.cc
+++ b/windows/windows_taskbar.cc
@@ -51,7 +51,9 @@ WindowsTaskbar::~WindowsTaskbar() {
 }
 
 bool WindowsTaskbar::SetProgressMode(int32_t mode) {
+  last_error_ = "";
   if (!::IsWindowVisible(window_)) {
+    LOG_ERROR("SetProgressMode failed: Window is not visible.");
     return false;
   }
 
@@ -68,6 +70,7 @@ bool WindowsTaskbar::SetProgressMode(int32_t mode) {
 }
 
 bool WindowsTaskbar::SetProgress(int32_t completed, int32_t total) {
+  last_error_ = "";
   if (!::IsWindowVisible(window_)) {
     LOG_ERROR("SetProgress failed: Window is not visible.");
     return false;
@@ -188,11 +191,14 @@ bool WindowsTaskbar::SetThumbnailToolbar(
 }
 
 bool WindowsTaskbar::ResetThumbnailToolbar() {
+  last_error_ = "";
   return WindowsTaskbar::SetThumbnailToolbar({});
 }
 
 bool WindowsTaskbar::SetThumbnailTooltip(std::string tooltip) {
+  last_error_ = "";
   if (!::IsWindowVisible(window_)) {
+    LOG_ERROR("SetThumbnailTooltip failed: Window is not visible.");
     return false;
   }
 
@@ -206,7 +212,9 @@ bool WindowsTaskbar::SetThumbnailTooltip(std::string tooltip) {
 
 bool WindowsTaskbar::SetFlashTaskbarAppIcon(int32_t mode, int32_t flash_count,
                                             int32_t timeout) {
+  last_error_ = "";
   if (!::IsWindowVisible(window_)) {
+    LOG_ERROR("SetFlashTaskbarAppIcon failed: Window is not visible.");
     return false;
   }
 
@@ -221,7 +229,9 @@ bool WindowsTaskbar::SetFlashTaskbarAppIcon(int32_t mode, int32_t flash_count,
 }
 
 bool WindowsTaskbar::ResetFlashTaskbarAppIcon() {
+  last_error_ = "";
   if (!::IsWindowVisible(window_)) {
+    LOG_ERROR("ResetFlashTaskbarAppIcon failed: Window is not visible.");
     return false;
   }
 
@@ -236,7 +246,9 @@ bool WindowsTaskbar::ResetFlashTaskbarAppIcon() {
 }
 
 bool WindowsTaskbar::SetOverlayIcon(std::string icon, std::string tooltip) {
+  last_error_ = "";
   if (!::IsWindowVisible(window_)) {
+    LOG_ERROR("SetOverlayIcon failed: Window is not visible.");
     return false;
   }
 
@@ -257,7 +269,9 @@ bool WindowsTaskbar::SetOverlayIcon(std::string icon, std::string tooltip) {
 }
 
 bool WindowsTaskbar::ResetOverlayIcon() {
+  last_error_ = "";
   if (!::IsWindowVisible(window_)) {
+    LOG_ERROR("ResetOverlayIcon failed: Window is not visible.");
     return false;
   }
 
@@ -269,7 +283,9 @@ bool WindowsTaskbar::ResetOverlayIcon() {
 }
 
 bool WindowsTaskbar::SetWindowTitle(std::string title) {
+  last_error_ = "";
   if (!::IsWindowVisible(window_)) {
+    LOG_ERROR("SetWindowTitle failed: Window is not visible.");
     return false;
   }
 
@@ -284,7 +300,9 @@ bool WindowsTaskbar::SetWindowTitle(std::string title) {
 }
 
 bool WindowsTaskbar::ResetWindowTitle() {
+  last_error_ = "";
   if (!::IsWindowVisible(window_)) {
+    LOG_ERROR("ResetWindowTitle failed: Window is not visible.");
     return false;
   }
 

--- a/windows/windows_taskbar.h
+++ b/windows/windows_taskbar.h
@@ -60,6 +60,8 @@ class WindowsTaskbar {
   const std::string& GetLastError() const { return last_error_; }
 
  private:
+  void ResetLastError();
+
   HWND window_ = nullptr;
   ITaskbarList3* taskbar_ = nullptr;
   bool thumb_buttons_added_ = false;


### PR DESCRIPTION
Description
This PR addresses internal issues within the plugin's native Windows implementation where the last_error_ state was not being properly managed. Previously, this led to confusing or incorrect error reporting being sent to the Flutter side.

Changes

Reset last_error_ on Every Method Call: Added last_error_ = ""; at the start of all public-facing methods in the WindowsTaskbar class (e.g., SetProgressMode, SetProgress, SetThumbnailTooltip, SetFlashTaskbarAppIcon). This ensures that errors retrieved via GetLastError() are specific to the most recent operation, preventing "ghost" errors carried over from previous failed calls.

Explicit Logging for Window Visibility Failures: Implemented explicit LOG_ERROR calls for methods that return early when a window is not visible (!::IsWindowVisible(window_)).

Improved Error Clarity: Previously, methods like SetProgressMode would return false without updating last_error_, causing the plugin to report stale errors from the buffer (e.g., a failed SetThumbnailToolbar). Now, these methods correctly report descriptive errors, such as: "SetProgressMode failed: Window is not visible."



描述
此 PR 解决了插件在 Windows 原生实现中的内部问题，即 last_error_ 状态管理不当，导致传递给 Flutter 端的错误报告含糊不清或出现错误。

变更点

在每次方法调用时重置 last_error_：
在 WindowsTaskbar 类（如 SetProgressMode、SetProgress、SetThumbnailTooltip、SetFlashTaskbarAppIcon 等）的所有对外公开方法开头添加了 last_error_ = "";。这确保了通过 GetLastError() 获取的错误仅针对当前操作，而不会沿用之前失败调用留下的错误状态。

增加窗口可见性失败的明确日志：
针对因窗口不可见（!::IsWindowVisible(window_)）而提前返回的方法，实现了明确的 LOG_ERROR 调用。

提高错误报告的准确性：
此前，像 SetProgressMode 这样的方法在返回 false 时不会更新 last_error_，导致插件报告缓冲区中残留的旧错误（例如之前失败的 SetThumbnailToolbar 产生的错误）。现在，这些方法能正确报告描述性错误，例如：“SetProgressMode failed: Window is not visible.”